### PR TITLE
Some suggestions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    step-track (0.4.3)
+    step-track (0.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -16,4 +16,4 @@ DEPENDENCIES
   step-track!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    step-track (0.5.0)
+    step-track (0.5.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # step_track
+
+## Test
+
+`ruby -Ilib:test test/runner.rb`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # step_track
 
+    gem install step_track
+
+## Usage
+
+    StepTrack.init("some_track_name") do |payload|
+      # process the payload once StepTrack.done is called
+    end
+
+    StepTrack.push("some_track_name", "some_step_name", foo: "bar")
+    StepTrack.push("some_track_name", "another_step_name", bar: "foo")
+    StepTrack.push("some_track_name", "same_step_name", foo: "bar", gnu: :tar)
+    StepTrack.push("some_track_name", "same_step_name", foo: "bar", gnu: :gzip)
+
+    StepTrack.done("some_track_name")
+
 ## Test
 
-`ruby -Ilib:test test/runner.rb`
+    ruby -Ilib:test test/runner.rb

--- a/lib/step_track.rb
+++ b/lib/step_track.rb
@@ -95,7 +95,7 @@ module StepTrack
   end
 
   def find_caller(caller)
-    caller[1]
+    caller[0]
   end
 
   def shorten_caller(caller)

--- a/lib/step_track.rb
+++ b/lib/step_track.rb
@@ -23,7 +23,6 @@ module StepTrack
     last_step = track_ref[:steps].last
     track_ref[:steps] << (merge_step || {}).merge(
       split: Time.now.to_f - (last_step&.[](:time) || track_ref[:time]).to_f,
-      duration: Time.now.to_f - track_ref[:time].to_f,
       time: Time.now,
       caller: merge_step&.[](:caller) || shorten_caller(caller),
       step_name: merge_step&.[](:step_name) || name
@@ -85,7 +84,7 @@ module StepTrack
   end
 
   def find_caller(caller)
-    caller[0]
+    caller[1]
   end
 
   def shorten_caller(caller)

--- a/lib/step_track/version.rb
+++ b/lib/step_track/version.rb
@@ -1,3 +1,3 @@
 module StepTrack
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/lib/step_track/version.rb
+++ b/lib/step_track/version.rb
@@ -1,3 +1,3 @@
 module StepTrack
-  VERSION = "0.4.4"
+  VERSION = "0.5.0"
 end

--- a/test/step_track_test.rb
+++ b/test/step_track_test.rb
@@ -48,7 +48,7 @@ describe "StepTrack" do
       assert_equal 1, data[:steps].size
       assert_equal "step", step[:step_name]
       assert_equal "bar", step[:moo]
-      expected_keys = [:split, :duration, :time, :caller]
+      expected_keys = [:split, :time, :caller]
       assert_equal expected_keys, expected_keys & step.keys
     end
 
@@ -104,7 +104,7 @@ describe "StepTrack" do
 
     it "sets a caller" do
       result = StepTrack.done("test")
-      assert_equal "test/step_track_test.rb:68:in `block (3 levels) in <top (required)>'", result[:caller]
+      assert_match %r{gems/minitest-.+/lib/minitest/spec.rb:\d+:in `instance_eval'}, result[:caller]
     end
 
     it "does not merge final step into results" do
@@ -121,7 +121,7 @@ describe "StepTrack" do
 
     it "enumerates every step into result" do
       result = StepTrack.done("test")
-      expected_key_parts = [:split, :duration, :caller]
+      expected_key_parts = [:i, :split, :caller]
 
       ["step", "last"].each_with_index do |n, i|
         expected_keys = expected_key_parts.map { |k| "step_#{n}_#{k}".to_sym }
@@ -132,7 +132,7 @@ describe "StepTrack" do
     it "enumerate duplicated step names with index in the result" do
       StepTrack.push("test", "last", gnu: "blu")
       result = StepTrack.done("test")
-      expected_key_parts = [:split, :duration, :caller]
+      expected_key_parts = [:i, :split, :caller]
 
       ["step", "last", "last_1"].each_with_index do |n, i|
         expected_keys = expected_key_parts.map { |k| "step_#{n}_#{k}".to_sym }

--- a/test/step_track_test.rb
+++ b/test/step_track_test.rb
@@ -23,7 +23,7 @@ describe "StepTrack" do
         "callback is no proc #{data[:callback].inspect}"
       assert data[:time] <= Time.now,
         "time #{data[:time].inspect} > #{Time.now.inspect}"
-      assert_match %r{minitest}, data[:caller]
+      assert_match %r{#{Regexp.escape(__FILE__)}}, data[:caller]
       assert_equal "1234", data[:track_id]
     end
   end
@@ -111,7 +111,7 @@ describe "StepTrack" do
 
     it "sets a caller" do
       result = StepTrack.done("test")
-      assert_match %r{gems/minitest-.+/lib/minitest/spec.rb:\d+:in `instance_eval'}, result[:caller]
+      assert_match %r{#{Regexp.escape(__FILE__)}}, result[:caller]
     end
 
     it "does not merge final step into results" do

--- a/test/step_track_test.rb
+++ b/test/step_track_test.rb
@@ -90,11 +90,26 @@ describe "StepTrack" do
       assert_equal 2, result[:step_count]
     end
 
-    it "merges the last step into result" do
+    it "sets the final step name" do
       result = StepTrack.done("test")
       assert_equal "last", result[:final_step_name]
-      expected_keys = [:split, :duration, :caller]
-      assert_equal expected_keys, expected_keys & result.keys
+    end
+
+    it "sets a duration" do
+      result = StepTrack.done("test")
+      assert result[:duration].is_a?(Float), "duration is no Float"
+      assert result[:duration] > 0.0, "duration is not positive"
+      assert result[:duration] < 1.0, "duration is too long"
+    end
+
+    it "sets a caller" do
+      result = StepTrack.done("test")
+      assert_equal "test/step_track_test.rb:68:in `block (3 levels) in <top (required)>'", result[:caller]
+    end
+
+    it "does not merge final step into results" do
+      result = StepTrack.done("test")
+      assert !result.key?(:gnu), "merged gnu into result"
     end
 
     it "merges the error into result when available" do


### PR DESCRIPTION
- Do not merge the last step into the root payload. Any step could be the last, thus the result is a fairly random set of keys on the root payload. We're filtering these back out in our client app and that's tedious.
- Added the `duration` since `init` to the root payload (should be same as before)
- Added the `caller` of `init` to the root payload (instead of the `caller` of the last `push`
- Added the option to set a `track_id` in config that is added to the root payload and that can be get while the track runs. This helps us cross-reference multiple tracks and metrics.
- Shorten `caller` by more than just `Dir.pwd`; added gem and bundler as well as rails root (all if defined)
- A very brief how-to
